### PR TITLE
Fix assert task typo

### DIFF
--- a/tasks/ps-rule-assert/powershell.ts
+++ b/tasks/ps-rule-assert/powershell.ts
@@ -31,7 +31,7 @@ async function run() {
         contents.push(`Import-Module $sdkPath -ArgumentList @{ NonInteractive = 'true' }`);
 
         // Prepare parameters
-        contents.push(`$scriptParams = @{ Path = '${input_path}'; InputType = '${input_inputType}' }; InputPath = '${input_inputPath}' };`);
+        contents.push(`$scriptParams = @{ Path = '${input_path}'; InputType = '${input_inputType}'; InputPath = '${input_inputPath}' };`);
         if (input_source !== undefined) {
             contents.push(`$scriptParams['Source'] = '${input_source}'`);
         }


### PR DESCRIPTION
## PR Summary

- Fix typo in assert task when setting input path.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/BernieWhite/PSRule-pipelines/blob/master/CHANGELOG.md) has been updated with change under unreleased section
